### PR TITLE
Remove copy of update script readme

### DIFF
--- a/source/manual/generate-rsf.html.erb
+++ b/source/manual/generate-rsf.html.erb
@@ -1,13 +1,10 @@
 ---
 title: Generate RSF updates for a register
-source_url: https://raw.githubusercontent.com/openregister/deployment/master/scripts/readme.md
 ---
 
 <h1 id="generate-rsf">Generate RSF updates for a register</h1>
 
 <h2>Scripts</h2>
 <p>
-This section is imported from <a href="https://github.com/openregister/deployment/tree/master/scripts">openregister/deployment/scripts</a>.
+See <a href="https://github.com/openregister/deployment/tree/master/scripts">openregister/deployment/scripts</a>.
 </p>
-
-<%= ExternalDoc.fetch(repository: 'openregister/deployment', path: 'scripts/readme.md') %>


### PR DESCRIPTION
Since the readme changed for the update scripts this page hasn't been updated. A link to it should suffice.